### PR TITLE
feat: mark new courses as self-paced [BB-7401]

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,14 @@ Unreleased
 
 *
 
+[0.3.0] - 2023-05-12
+********************
+
+Changed
+=======
+
+* New section-based courses are self-paced.
+
 [0.2.0] - 2023-05-10
 ********************
 

--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,24 @@ Then, in your ``devstack`` directory, run:
     cd /edx/src/section-to-course
     pip install -e .
 
+Configuration (optional)
+************************
+
+New courses are self-paced. If you want to set relative deadlines in them, follow the next steps:
+
+#. Add the following `Waffle Flags`_ (with ``Everyone: Yes``) in Django admin:
+
+    #. `studio.custom_relative_dates`_
+    #. `course_experience.relative_dates`_
+    #. `course_experience.relative_dates_disable_reset`_
+#. Go to `Django admin -> Course_Date_Signals -> Self paced relative dates`_ configs and add a config with ``Enabled: Yes``.
+
+.. _Waffle Flags: http://localhost:18000/admin/waffle/flag/
+.. _studio.custom_relative_dates: https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-studio.custom_relative_dates
+.. _course_experience.relative_dates: https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-course_experience.relative_dates
+.. _course_experience.relative_dates_disable_reset: https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-course_experience.relative_dates_disable_reset
+.. _Django admin -> Course_Date_Signals -> Self paced relative dates: http://localhost:18000/admin/course_date_signals/selfpacedrelativedatesconfig/
+
 
 Usage
 *****
@@ -57,6 +75,15 @@ Usage
 Once installed, the plugin should automatically register itself within Django. Be sure to run database migrations.
 
 The admin views are in the Django admin, under the "Section to Course" section. From there, you can create a new section to course link, which will create a new course with the same content as the section you selected. You can also view the list of existing section to course links, refresh them, and delete them.
+
+Relative due dates (optional)
+=============================
+
+If you want to configure relative deadlines in your course, follow these steps:
+
+#. Mark a subsection in the newly created course as graded (otherwise, deadlines will be enforced but learners will not see these dates in the LMS).
+#. Enter the number of weeks in the subsection's "Due in" field.
+#. You may also want to adjust the new course's grading policy to change the weight of the section.
 
 Refreshing a Course
 ===================

--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,8 @@ Once installed, the plugin should automatically register itself within Django. B
 
 The admin views are in the Django admin, under the "Section to Course" section. From there, you can create a new section to course link, which will create a new course with the same content as the section you selected. You can also view the list of existing section to course links, refresh them, and delete them.
 
+**Note:** The start date of a newly created course is in the future, so you will likely want to modify it in the "Schedule & Details" section in Studio.
+
 Relative due dates (optional)
 =============================
 

--- a/section_to_course/__init__.py
+++ b/section_to_course/__init__.py
@@ -2,4 +2,4 @@
 Factors sections from Open edX courses into their own new course.
 """
 
-__version__ = '0.2.0'
+__version__ = '0.3.0'

--- a/section_to_course/admin.py
+++ b/section_to_course/admin.py
@@ -252,6 +252,7 @@ class CreateSectionToCourseLink(forms.ModelForm):
             number=number,
             run=run,
             display_name=cleaned_data['new_course_name'],
+            self_paced=True,
         )
         return paste_from_template(
             destination_course_key=course.id,

--- a/section_to_course/compat.py
+++ b/section_to_course/compat.py
@@ -16,6 +16,7 @@ def create_course(
     number: str,
     run: str,
     display_name: str,
+    self_paced: bool = False,
 ):
     """
     Create a course to match a specific course key.
@@ -27,7 +28,7 @@ def create_course(
         org=org,
         number=number,
         run=run,
-        fields={'display_name': display_name}
+        fields={'display_name': display_name, 'self_paced': self_paced},
     )
 
 

--- a/section_to_course/tests/test_admin.py
+++ b/section_to_course/tests/test_admin.py
@@ -122,6 +122,7 @@ class TestSectionToCourseLinkAdmin(ModuleStoreTestCase, TestCase):
         assert dest_course.org == org.short_name
         assert dest_course.number == 'NC101'
         assert dest_course.location.run == '2023'
+        assert dest_course.self_paced
         # Should not create a new link if it's already made.
         response = self.create_section_to_course_link(course, section, org)
         assert 'A course with this number, org, and run already exists.' in response.content.decode('utf-8')


### PR DESCRIPTION
This changes the new course to be self-paced instead of instructor-paced.

## Testing instructions.
1. Follow the steps added to the README.
2. Create a new section-based course in the Django admin.
3. Check that the course is self-paced (`Studio -> Schedule & Details`).
4. If you want to check if the relative dates work as expected, you can use the instructions from https://github.com/openedx/edx-platform/pull/32148. <s>Please note that the Waffle flag to enforce these dates is currently broken in Nutmeg - you can use the branch from https://github.com/open-craft/edx-platform/pull/539 (unless it's merged before you review this)</s>.

## Author's notes
<s>1. Adding relative due dates to sections is a manual step because we will need to change the grading policy for new courses to ensure that completing the section results in a 100% grade from the whole course. This is a more significant change, so it's outside of this ticket's scope.
2. Once the previous point is completed, we can mark the section as graded while creating the course. We can also allow setting the number of relative weeks from the admin form (if needed).</s>
I thought about this a bit more and realized that I've been talking about **sections**, but the **subsections** are actually graded. I then tested the `cms.djangoapps.models.settings.course_grading.update_section_grader_type` method, and it turns out that it's possible to mark the whole section as graded. It's even displayed on the Course Outline page in Studio as such (without using this API there is no graded/ungraded indication there). However, it's impossible to modify this option on the Studio page, so we don't want to use this approach.
Then, I thought about the second thing - i.e., setting a custom grading policy in the newly created course. We can do this with the `CourseGradingModel` mentioned above, but there could be multiple subsections in the "Lesson", so we don't know if all of them should be graded (and if they should be graded equally). Therefore, keeping the grading settings as a manual step sounds logical until we obtain more requirements from the client.

We could set up a default relative date (`Number of Relative Weeks Due By` in the "Advanced Settings"; `relative_weeks_due` directly in the Course XBlock). However, it means that this date will be enforced for Problem blocks in ungraded sections, without informing learners about them anywhere (I've mentioned this in the README). Therefore, this would be a confusing behavior for both learners and course authors.

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
