### PR TITLE
fix: use TEST_PASSWORD variable in tests + quince & palm as test targets

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -20,6 +20,12 @@ jobs:
           - branch: opencraft-release/nutmeg.2
             remote: open-craft
             release: nutmeg
+          - branch: opencraft-release/palm.1
+            remote: open-craft
+            release: palm
+          - branch: open-release/quince.master
+            remote: openedx
+            release: quince
           - branch: master
             remote: openedx
             release: master

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,13 @@ Change Log
 Unreleased
 **********
 
+[0.4.1] - 2023-11-07
+********************
+
+Fixed
+=======
+
+* Compatibility of ``compat`` imports with Palm.
 
 [0.4.0] - 2023-05-18
 ********************

--- a/section_to_course/__init__.py
+++ b/section_to_course/__init__.py
@@ -2,4 +2,4 @@
 Factors sections from Open edX courses into their own new course.
 """
 
-__version__ = '0.4.0'
+__version__ = '0.4.1'

--- a/section_to_course/api/tests/test_views.py
+++ b/section_to_course/api/tests/test_views.py
@@ -3,7 +3,7 @@ Tests for the API views of section_to_course.
 """
 
 # pylint: disable=no-self-use
-from common.djangoapps.student.tests.factories import UserFactory, TEST_PASSWORD
+from common.djangoapps.student.tests.factories import TEST_PASSWORD, UserFactory
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -47,7 +47,7 @@ class TestSectionAutoCompleteAPI(ModuleStoreTestCase, APITestCase):
         response = self.client.get(
             reverse('section_to_course:section_autocomplete', kwargs={'course_id': 'course-v1:edX+DemoX+Demo_Course'})
         )
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
 
     def test_rejects_unauthorized(self):
         """

--- a/section_to_course/api/tests/test_views.py
+++ b/section_to_course/api/tests/test_views.py
@@ -3,7 +3,7 @@ Tests for the API views of section_to_course.
 """
 
 # pylint: disable=no-self-use
-from common.djangoapps.student.tests.factories import UserFactory
+from common.djangoapps.student.tests.factories import UserFactory, TEST_PASSWORD
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -54,7 +54,7 @@ class TestSectionAutoCompleteAPI(ModuleStoreTestCase, APITestCase):
         Test that the API rejects unauthorized users.
         """
         user = UserFactory.create()
-        assert self.client.login(username=user.username, password='test')
+        assert self.client.login(username=user.username, password=TEST_PASSWORD)
         response = self.client.get(
             reverse('section_to_course:section_autocomplete', kwargs={'course_id': 'course-v1:edX+DemoX+Demo_Course'})
         )
@@ -65,7 +65,7 @@ class TestSectionAutoCompleteAPI(ModuleStoreTestCase, APITestCase):
         Test that the API rejects malformed course IDs.
         """
         user = UserFactory.create(is_staff=True)
-        assert self.client.login(username=user.username, password='test')
+        assert self.client.login(username=user.username, password=TEST_PASSWORD)
         response = self.client.get(
             reverse('section_to_course:section_autocomplete', kwargs={'course_id': 'malarkey'})
         )
@@ -76,7 +76,7 @@ class TestSectionAutoCompleteAPI(ModuleStoreTestCase, APITestCase):
         Test that the API rejects malformed course IDs.
         """
         user = UserFactory.create(is_staff=True)
-        assert self.client.login(username=user.username, password='test')
+        assert self.client.login(username=user.username, password=TEST_PASSWORD)
         response = self.client.get(
             reverse('section_to_course:section_autocomplete', kwargs={'course_id': 'course-v1:edX+DemoX+Demo_Course'}),
         )
@@ -87,7 +87,7 @@ class TestSectionAutoCompleteAPI(ModuleStoreTestCase, APITestCase):
         Test that blank terms return all sections.
         """
         user = UserFactory.create(is_staff=True)
-        assert self.client.login(username=user.username, password='test')
+        assert self.client.login(username=user.username, password=TEST_PASSWORD)
         create_subsections()
         response = self.client.get(
             reverse('section_to_course:section_autocomplete', kwargs={'course_id': 'course-v1:edX+DemoX+Demo_Course'}),
@@ -105,7 +105,7 @@ class TestSectionAutoCompleteAPI(ModuleStoreTestCase, APITestCase):
         Test that autocomplete filters existing sections.
         """
         user = UserFactory.create(is_staff=True)
-        assert self.client.login(username=user.username, password='test')
+        assert self.client.login(username=user.username, password=TEST_PASSWORD)
         section_data = create_subsections()
         SectionToCourseLinkFactory(source_course=section_data['course'], source_section=section_data['experimentation'])
         response = self.client.get(
@@ -123,7 +123,7 @@ class TestSectionAutoCompleteAPI(ModuleStoreTestCase, APITestCase):
         Test that autocomplete filters names.
         """
         user = UserFactory.create(is_staff=True)
-        assert self.client.login(username=user.username, password='test')
+        assert self.client.login(username=user.username, password=TEST_PASSWORD)
         create_subsections()
         response = self.client.get(
             reverse('section_to_course:section_autocomplete', kwargs={'course_id': 'course-v1:edX+DemoX+Demo_Course'})
@@ -141,7 +141,7 @@ class TestSectionAutoCompleteAPI(ModuleStoreTestCase, APITestCase):
         Test that autocomplete filters keys.
         """
         user = UserFactory.create(is_staff=True)
-        assert self.client.login(username=user.username, password='test')
+        assert self.client.login(username=user.username, password=TEST_PASSWORD)
         create_subsections()
         response = self.client.get(
             reverse('section_to_course:section_autocomplete', kwargs={'course_id': 'course-v1:edX+DemoX+Demo_Course'})

--- a/section_to_course/compat.py
+++ b/section_to_course/compat.py
@@ -92,10 +92,15 @@ def duplicate_block(
     Duplicate a block using the upstream function.
     """
     try:
+        # Quince and newer
         from cms.djangoapps.contentstore.utils import duplicate_block as upstream_duplicate_block
     except ImportError:
-        # This is no longer needed in Palm.
-        from cms.djangoapps.contentstore.views.item import duplicate_block as upstream_duplicate_block
+        try:
+            # Palm
+            from cms.djangoapps.contentstore.views.block import duplicate_block as upstream_duplicate_block
+        except ModuleNotFoundError:
+            # Nutmeg
+            from cms.djangoapps.contentstore.views.item import duplicate_block as upstream_duplicate_block
     return upstream_duplicate_block(
         parent_usage_key=destination_course.location,
         duplicate_source_usage_key=source_block_usage_key,
@@ -115,10 +120,15 @@ def update_from_source(
     Update a block's attributes from a source block. See upstream function.
     """
     try:
+        # Quince and newer
         from cms.djangoapps.contentstore.utils import update_from_source as upstream_update_from_source
     except ImportError:
-        # This is no longer needed in Palm.
-        from cms.djangoapps.contentstore.views.item import update_from_source as upstream_update_from_source
+        try:
+            # Palm
+            from cms.djangoapps.contentstore.views.block import update_from_source as upstream_update_from_source
+        except ModuleNotFoundError:
+            # Nutmeg
+            from cms.djangoapps.contentstore.views.item import update_from_source as upstream_update_from_source
     upstream_update_from_source(
         source_block=source_block, destination_block=destination_block, user_id=user.id,
     )

--- a/section_to_course/tests/test_admin.py
+++ b/section_to_course/tests/test_admin.py
@@ -1,7 +1,7 @@
 """
 Tests for the admin views of the section_to_course app.
 """
-from common.djangoapps.student.tests.factories import UserFactory  # pylint: disable=import-error
+from common.djangoapps.student.tests.factories import UserFactory, TEST_PASSWORD  # pylint: disable=import-error
 from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
@@ -31,7 +31,7 @@ class TestSectionToCourseLinkAdmin(ModuleStoreTestCase, TestCase):
         """Set up our admin test cases."""
         super().setUp()
         user = UserFactory.create(is_staff=True, is_superuser=True)
-        self.client.login(username=user.username, password='test')
+        self.client.login(username=user.username, password=TEST_PASSWORD)
 
     def test_listing(self):
         """Test that the admin listing page loads."""

--- a/section_to_course/tests/test_admin.py
+++ b/section_to_course/tests/test_admin.py
@@ -1,7 +1,7 @@
 """
 Tests for the admin views of the section_to_course app.
 """
-from common.djangoapps.student.tests.factories import UserFactory, TEST_PASSWORD  # pylint: disable=import-error
+from common.djangoapps.student.tests.factories import TEST_PASSWORD, UserFactory  # pylint: disable=import-error
 from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone


### PR DESCRIPTION
**Description**
The integration tests are [failing](https://github.com/open-craft/section-to-course/actions/runs/6607873335/job/18017503640?pr=31) due to a change in the UserFactory's [default password](https://github.com/openedx/edx-platform/commit/1e2ea85372cf777122cb1f13c7c6a63c982b8790#diff-393953656c5bb3c246b84f1409586cdb095d4f4014c2608b9fda9463381f8247R84).  
This MR addresses that by relying on a [variable](https://github.com/openedx/edx-platform/blob/1e2ea85372cf777122cb1f13c7c6a63c982b8790/common/djangoapps/student/tests/factories.py#L38) available in the `factories` module.



**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
